### PR TITLE
1.14.4 (#15)

### DIFF
--- a/src/js/api/index.js
+++ b/src/js/api/index.js
@@ -1,3 +1,6 @@
+import {escape_url_param} from '../helper/security';
+
+
 class API {
     static HOST_MILLIX_API  = 'https://localhost:5500/api';
     static HOST_TANGLED_API = 'https://localhost:15555/api';
@@ -209,6 +212,9 @@ class API {
 
     newSessionWithPhrase(password, mnemonicPhrase) {
         try {
+            password       = escape_url_param(password);
+            mnemonicPhrase = escape_url_param(mnemonicPhrase);
+
             return fetch(this.getAuthenticatedMillixApiURL() + `/GktuwZlVP39gty6v?p0=${password}&p1=${mnemonicPhrase}`)
                 .then(response => response.ok ? response.json() : Promise.reject());
         }
@@ -219,6 +225,7 @@ class API {
 
     newSession(password) {
         try {
+            password = escape_url_param(password);
             return fetch(this.getAuthenticatedMillixApiURL() + `/PMW9LXqUv7vXLpbA?p0=${password}`)
                 .then(response => response.ok ? response.json() : Promise.reject());
         }

--- a/src/js/components/unlock-wallet-view.jsx
+++ b/src/js/components/unlock-wallet-view.jsx
@@ -93,9 +93,10 @@ class UnlockWalletView extends Component {
             const error_list = [];
             API.newSession(password)
                .then(data => {
-                   if (data.api_status === 'fail') {
+                   if (data.api_status !== 'success') {
                        return;
                    }
+
                    goToWalletView(data.wallet);
                }).catch(_ => {
                 props.walletReady({authenticationError: true});
@@ -207,11 +208,6 @@ class UnlockWalletView extends Component {
                                                                                     }
                                                                                 }}
                                                                             />
-                                                                            {props.wallet.authenticationError ? (
-                                                                                <span
-                                                                                    className="help-block small">there was a problem authenticating your key file. retry your password or <a
-                                                                                    style={{cursor: 'pointer'}}
-                                                                                    onClick={() => props.history.push('/import-wallet/')}> click here to load your key.</a></span>) : ''}
                                                                         </div>
                                                                         <Button
                                                                             variant="outline-primary"

--- a/src/js/components/wallet-view.jsx
+++ b/src/js/components/wallet-view.jsx
@@ -311,7 +311,7 @@ class WalletView extends Component {
                                                 on_accept={() => this.sendTransaction()}
                                                 on_close={() => this.cancelSendTransaction()}
                                                 body={<div>you are about to
-                                                    send {format.millix(this.state.amount)} to {this.state.address_key_identifier}{this.state.address_version}{this.state.address_base}.
+                                                    send {format.millix(this.state.amount)} to {this.state.address_base}{this.state.address_version}{this.state.address_key_identifier}
                                                     <div>confirm that you want
                                                         to
                                                         continue.</div></div>}/>

--- a/src/js/helper/security.js
+++ b/src/js/helper/security.js
@@ -1,0 +1,3 @@
+export function escape_url_param(string) {
+    return encodeURIComponent(string);
+}


### PR DESCRIPTION
* left nav, style changes (#1)

left nav styles
roboto font
convert css to scss
utc clock
move version to left nav botton
add variable.scss

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* environment file

* working bootstrap
broken layout

* base left nav
base top nav

* mixin_and_variable.scss
button.scss
panel.scss
update fontawesome version

* replace hardcoded button styles

* label
panel.scss
buttons

* cleanup
table

* nav toggle

* cleanup
fee input group addon

* datatable

* datatable
peer-list-view.jsx
transaction-history-view.jsx
wallet-view.jsx

* datatable-view.jsx

* datatable-view.jsx paginator
dropdown.scss

* default rows 20

* unspent-transaction-output-view.jsx
left nav

* report issue
getNodeOsInfo
sidebar.jsx expandable icons

* Issue/millix 38 bootstrap (#3)

* MILLIX-38: unlock screen design

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* unlock screen design

* datatable-action-button-view.jsx
left nav restructure
peer-list-view.jsx detail button
fix process is not defined

* showActionColumn
transaction-history-view.jsx - action button
unspent-transaction-output-view.jsx - properly reload datatable

* design report-issue-view.jsx
design stats-view.jsx

* unspent-transaction-output-list fix state usage

* mixin
confirm modal
action-view.jsx - confirm reset and redirect on pending when done

* Issue/millix 53 (#4)

* MILLIX-53: error notification module

* Issue/millix 63 (#5)

* MILLIX-63: sidenav highlight fixes
* MILLIX-63: sidenav auto-expansion

* ad form, modals, help icon, faq, import/new wallet, modal footer (#8)

* fix error

* datatable action row styles
reload button and timer

* ad list play pause
ad form

* modal
switch to bootstrap confirmation modal

* help-icon-view.jsx
wallet-view.jsx - handle 128+ inputs

* faq-view.jsx

* cleanup css and create-ad-view.jsx

* new wallet flow style

* modal footer style
new-wallet-view.jsx/ import-wallet-view.jsx back button and styles

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* datatable-view.jsx default values (#9)

datatable-view.jsx default values
help-icon-view.jsx - transaction_max_input_number
list-ad-view.jsx - cleanup
transaction-details-view.jsx
wallet-view.jsx - handle 128+ input tx error

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* unlock, create, import screens design and labels

* MILLIX-64: unlock screen without existing private_key (#7)

* MILLIX-64: check if private_key exists on unlock screen

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* datatable header, loader, icons, create ad validation (#10)

* datatable-header-view.jsx
datatable loading
report-issue-view.jsx - change arch to architecture
create-ad-view.jsx - remove bid per impression cannot exceed the daily budget and please add funds to enable this ad campaign errors
action-view.jsx - reset validation modal text

* replace edit icon with eye when it is view only page

* prevent fatal. needs additional fix

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-29: add logout confirmation popup (#11)

MILLIX-29: add logout confirmation popup

* Millix 30 (#12)

MILLIX-30: add modal send confirmation

* MILLIX-76: redesign peer detail page (#13)

* MILLIX-76: redesign peer detail page

* balance, addresses, bug fixes, ad validation, errors, send result (#14)

* do not show node public address if node is not public
* MILLIX-78 - left nav glitch on low resolution
* MILLIX-79 - do not show node public address if node is not public
* MILLIX-78 - left nav glitch on low resolution
* MILLIX-82 - create ad amounts validation. restore validation bid_per_impressions_mlx against daily budget
* MILLIX-56 - send tx with 128+ inputs error message and hints
* MILLIX-80 - amount sorting bodyTemplateAmount
refactor datatable usages
* MILLIX-83 - make error list less aggressive
* format helper
send confirmation modal text
* modal-view.jsx - on_close
send - fix confirmation modal
* MILLIX-84 - balance-view.jsx
MILLIX-85 - address-list-view.jsx
cleanup moment.relativeTimeThreshold
format.date
* primary_address hints
* cleanup tables
* MILLIX-83 - standardize stable/pending unspent related terms
* MILLIX-83 - show transaction id in send result modal
unspent-transaction-output-view.jsx - notes

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-76 - peer detail (#15)

MILLIX-76 - peer detail

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-89 - create-ad-view.jsx sort categories by label, list-ad-view fix empty categories and types, fix create button label (#16)

* MILLIX-89 - list-ad-view fix empty categories and types, fix create button label
* MILLIX-89 - create-ad-view.jsx sort categories by label

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-84 - balance panel, update help items (#20)

MILLIX-84 - balance panel, update help items
update transaction details

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* millix 95 send empty error. improve validation (#21)

MILLIX-95 - wallet-view.jsx - handle errors. improve validation
help-icon-view.jsx remove trailing dots
validate.js helper
fix unlock-wallet-view.jsx error
fix .editorconfig max line length
Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* validate.handleAmountInputChange

* MILLIX-108 - datatable search (#23)

MILLIX-108 - datatable search
move datatable header in datatable view
MILLIX-107 - incomplete commented filter

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-109 - add key identifier to header, stats, report
fix private_key_exists variable name

* MILLIX-28 - fix unreliable sidebar node version

* datatable-view.jsx fix reload_datatable call

* wallet-view.jsx send - fix sending a few tx in a row

* MILLIX-118 - send confirmation message wrong address

* MILLIX-124 - newSession* escape url params before send (#24)

MILLIX-124 - newSession* escape url params before send
fix success condition: login consider everything but success as fail

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

Co-authored-by: ksenia404publishing <96577545+ksenia404publishing@users.noreply.github.com>
Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>
Co-authored-by: dkhaleev <dkhaleev@gmail.com>
Co-authored-by: antonshulpekov <98457590+antonshulpekov@users.noreply.github.com>