### PR TITLE
styling, fiat balance, messages (#21)

### DIFF
--- a/src/css/layout.scss
+++ b/src/css/layout.scss
@@ -353,14 +353,8 @@ ul {
 
   .stable_fiat {
     display: flex;
-    font-size: 2.4rem;
-    height: 0;
-    transition: height 0.3s;
+    font-size: 2rem;
     overflow: hidden;
-
-    &.show {
-      height: 2.4rem;
-    }
 
     > .symbol {
       margin-right: 0.3rem;
@@ -375,6 +369,10 @@ ul {
   .pending {
     font-size: 1.4rem;
     word-break: break-all;
+  }
+
+  .help_icon {
+    font-size: 1.12rem;
   }
 }
 

--- a/src/js/components/action/mnemonic-phrase-view.jsx
+++ b/src/js/components/action/mnemonic-phrase-view.jsx
@@ -61,7 +61,7 @@ class MnemonicPhraseView extends Component {
             <div className={'panel panel-filled'}>
                 <div className={'panel-heading bordered'}>backup</div>
                 <div className={'panel-body'}>
-                    <p>mnemonic phrase is a unique string that allows you to access your wallet. if you loose your mnemonic phrase you
+                    <p>mnemonic phrase is a unique string that allows you to access your wallet. if you lose your mnemonic phrase you
                         will not be able to access this wallet or any funds it contains. we recommend you to write these words down and
                         keep them in a safe place. avoid saving your mnemonic phrase in a computer or online service and do not take a
                         screenshot of it. millix_private_key.json contains your wallet mnemonic phrase.</p>

--- a/src/js/components/sidebar.jsx
+++ b/src/js/components/sidebar.jsx
@@ -194,6 +194,12 @@ class Sidebar extends Component {
                         </NavText>
                     </NavItem>
 
+                    <NavItem key={'trade'}>
+                        <NavText onClick={() => window.open('https://millix.com', '_blank').focus()}>
+                            trade
+                        </NavText>
+                    </NavItem>
+
                     <NavItem key={'address-list'} eventKey="/address-list">
                         <NavText>
                             addresses
@@ -247,6 +253,37 @@ class Sidebar extends Component {
                      </NavItem>
                      */}
 
+                    <NavItem key={'actions'} eventKey="/actions">
+                        <NavText>
+                            actions
+                        </NavText>
+                    </NavItem>
+
+                    <NavItem
+                        eventKey="status"
+                        expanded={this.isExpanded('status', defaultSelected)}
+                    >
+                        <NavText>
+                            status <FontAwesomeIcon className={'icon'}
+                                                    icon="chevron-down"
+                                                    size="1x"/>
+                            <FontAwesomeIcon className={'icon hidden'}
+                                             icon="chevron-up"
+                                             size="1x"/>
+                        </NavText>
+                        <NavItem key={'status-summary'}
+                                 eventKey="/status-summary">
+                            <NavText>
+                                summary
+                            </NavText>
+                        </NavItem>
+                        <NavItem key={'peers'} eventKey="/peers">
+                            <NavText>
+                                peers
+                            </NavText>
+                        </NavItem>
+                    </NavItem>
+
                     <NavItem
                         eventKey="config"
                         expanded={this.isExpanded('config', defaultSelected)}
@@ -283,37 +320,6 @@ class Sidebar extends Component {
                         <NavItem key={'config-address-version'} eventKey="/config/address-version">
                             <NavText>
                                 address version
-                            </NavText>
-                        </NavItem>
-                    </NavItem>
-
-                    <NavItem key={'actions'} eventKey="/actions">
-                        <NavText>
-                            actions
-                        </NavText>
-                    </NavItem>
-
-                    <NavItem
-                        eventKey="status"
-                        expanded={this.isExpanded('status', defaultSelected)}
-                    >
-                        <NavText>
-                            status <FontAwesomeIcon className={'icon'}
-                                                    icon="chevron-down"
-                                                    size="1x"/>
-                            <FontAwesomeIcon className={'icon hidden'}
-                                             icon="chevron-up"
-                                             size="1x"/>
-                        </NavText>
-                        <NavItem key={'status-summary'}
-                                 eventKey="/status-summary">
-                            <NavText>
-                                summary
-                            </NavText>
-                        </NavItem>
-                        <NavItem key={'peers'} eventKey="/peers">
-                            <NavText>
-                                peers
                             </NavText>
                         </NavItem>
                     </NavItem>

--- a/src/js/components/utils/balance-view.jsx
+++ b/src/js/components/utils/balance-view.jsx
@@ -24,20 +24,14 @@ class BalanceView extends Component {
     }
 
     render() {
-        let stable_fiat               = '';
-        let stable_fiat_toggle_button = '';
-        if (convert.is_currency_pair_summary_available()) {
-            stable_fiat_toggle_button = <div className="toggle_button_container" ref={this.toggleButtonRef}>
-                <FontAwesomeIcon
-                    className="toggle_button"
-                    onClick={() => this.handleClick()}
-                    icon="chevron-down"
-                    size="1x"/>
-            </div>;
+        let balance_stable_millix   = this.props.stable;
 
+        let stable_fiat               = '';
+        if (convert.is_currency_pair_summary_available()) {
             stable_fiat = <div ref={this.balanceStableFiatRef} className={'stable_fiat'}>
                 <span className="text-primary symbol">{store.getState().currency_pair_summary.symbol}</span>
-                <span>{convert.fiat(this.props.stable, false)}</span>
+                <span>{convert.fiat(balance_stable_millix, false)}</span>
+                <HelpIconView help_item_name={'buy_and_sell'}/>
             </div>;
         }
 
@@ -47,9 +41,8 @@ class BalanceView extends Component {
                     <div className={'balance_container'}>
                         {svg.millix_logo()}
                         <div className={'stable_millix'}>
-                            <span>{format.millix(this.props.stable, false)}</span>
+                            <span>{format.millix(balance_stable_millix, false)}</span>
                         </div>
-                        {stable_fiat_toggle_button}
                     </div>
                     {stable_fiat}
 

--- a/src/js/components/utils/error-handler-request-api.jsx
+++ b/src/js/components/utils/error-handler-request-api.jsx
@@ -32,7 +32,7 @@ class ErrorModalRequestApi extends Component {
                 let message = error.message;
 
                 if (error?.message === 'Failed to fetch') {
-                    message = 'failed to request node. please restart and try again.';
+                    message = 'a critical service is not responding. please close this application completely and reopen it to try again. if your issue persists click help on the left navigation to get assistance.';
                 }
 
                 this.showModal(message);

--- a/src/js/components/utils/help-icon-view.jsx
+++ b/src/js/components/utils/help-icon-view.jsx
@@ -208,6 +208,15 @@ class HelpIconView extends Component {
                         minimum fee your node will accept to verify transaction if it is chosen as proxy
                     </li>
                 </ul>
+            },
+            'buy_and_sell'                : {
+                'title': 'buy & sell millix',
+                'body' : <ul>
+                    <li>
+                        go to <a href="" onClick={() => window.open('https://millix.com', '_blank').focus()}>millix.com</a> and trade millix for
+                        bitcoin with zero fees
+                    </li>
+                </ul>
             }
         };
         let help_item     = false;

--- a/src/js/helper/format.js
+++ b/src/js/helper/format.js
@@ -13,10 +13,16 @@ export function millix(amount, append_name = true) {
 }
 
 export function fiat(amount) {
-    return get_fixed_value({
+    const param = {
         value      : amount,
         format_zero: true
-    });
+    };
+
+    if (amount > 1) {
+        param.float_part_length = 2;
+    }
+
+    return get_fixed_value(param);
 }
 
 export function number(number) {

--- a/src/js/helper/text.js
+++ b/src/js/helper/text.js
@@ -21,11 +21,10 @@ export function get_ui_error(api_message) {
 
         switch (api_error_name) {
             case 'transaction_input_max_error':
-                error = <>your
-                    transaction tried to use too many outputs<HelpIconView help_item_name={'transaction_max_input_number'}/>.
-                    please try to send a smaller amount or aggregate manually by sending a smaller
-                    amounts to yourself or aggregate unspents on this <a onClick={() => this.props.history.push('/actions')}>page</a>.
-                    the max amount you can send is {format.millix(api_message.data.amount_max)}.</>;
+                error = <>
+                    your transaction tried to use too many outputs<HelpIconView help_item_name={'transaction_max_input_number'}/> please try to send a smaller
+                    amount or click <a className={''} onClick={() => this.props.history.push('/actions')}>here</a> to use the balance aggregation tool to
+                    optimize your balance. the max amount you can send is {format.millix(api_message.data.amount_max)}.</>;
                 break;
             case 'insufficient_balance':
                 error = <>your balance is lower than the amount you are trying to send. the max amount you can send
@@ -47,7 +46,7 @@ export function get_ui_error(api_message) {
                 error = <>cannot aggregate the unspent deposits. the transaction value is too small</>;
                 break;
             default:
-                error = <>your transaction could not be sent: ({api_message?.error?.error || api_message?.error || api_message || 'undefined behaviour'})</>
+                error = <>your transaction could not be sent: ({api_message?.error?.error || api_message?.error || api_message || 'undefined behaviour'})</>;
                 break;
         }
     }

--- a/src/js/redux/reducers/index.js
+++ b/src/js/redux/reducers/index.js
@@ -74,7 +74,7 @@ function rootReducer(state = initialState, action) {
     }
 
     if (action.type === UNLOCK_WALLET) {
-        state = initialState;
+        // state = initialState; // todo: it cause empty config on login. use getNodeConfig() to populate
         return Object.assign({}, state, {
             wallet: {
                 ...state.wallet,


### PR DESCRIPTION
* left nav, style changes (#1)

left nav styles
roboto font
convert css to scss
utc clock
move version to left nav botton
add variable.scss

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* environment file

* working bootstrap
broken layout

* base left nav
base top nav

* mixin_and_variable.scss
button.scss
panel.scss
update fontawesome version

* replace hardcoded button styles

* label
panel.scss
buttons

* cleanup
table

* nav toggle

* cleanup
fee input group addon

* datatable

* datatable
peer-list-view.jsx
transaction-history-view.jsx
wallet-view.jsx

* datatable-view.jsx

* datatable-view.jsx paginator
dropdown.scss

* default rows 20

* unspent-transaction-output-view.jsx
left nav

* report issue
getNodeOsInfo
sidebar.jsx expandable icons

* Issue/millix 38 bootstrap (#3)

* MILLIX-38: unlock screen design

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* unlock screen design

* datatable-action-button-view.jsx
left nav restructure
peer-list-view.jsx detail button
fix process is not defined

* showActionColumn
transaction-history-view.jsx - action button
unspent-transaction-output-view.jsx - properly reload datatable

* design report-issue-view.jsx
design stats-view.jsx

* unspent-transaction-output-list fix state usage

* mixin
confirm modal
action-view.jsx - confirm reset and redirect on pending when done

* Issue/millix 53 (#4)

* MILLIX-53: error notification module

* Issue/millix 63 (#5)

* MILLIX-63: sidenav highlight fixes
* MILLIX-63: sidenav auto-expansion

* ad form, modals, help icon, faq, import/new wallet, modal footer (#8)

* fix error

* datatable action row styles
reload button and timer

* ad list play pause
ad form

* modal
switch to bootstrap confirmation modal

* help-icon-view.jsx
wallet-view.jsx - handle 128+ inputs

* faq-view.jsx

* cleanup css and create-ad-view.jsx

* new wallet flow style

* modal footer style
new-wallet-view.jsx/ import-wallet-view.jsx back button and styles

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* datatable-view.jsx default values (#9)

datatable-view.jsx default values
help-icon-view.jsx - transaction_max_input_number
list-ad-view.jsx - cleanup
transaction-details-view.jsx
wallet-view.jsx - handle 128+ input tx error

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* unlock, create, import screens design and labels

* MILLIX-64: unlock screen without existing private_key (#7)

* MILLIX-64: check if private_key exists on unlock screen

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* datatable header, loader, icons, create ad validation (#10)

* datatable-header-view.jsx
datatable loading
report-issue-view.jsx - change arch to architecture
create-ad-view.jsx - remove bid per impression cannot exceed the daily budget and please add funds to enable this ad campaign errors
action-view.jsx - reset validation modal text

* replace edit icon with eye when it is view only page

* prevent fatal. needs additional fix

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-29: add logout confirmation popup (#11)

MILLIX-29: add logout confirmation popup

* Millix 30 (#12)

MILLIX-30: add modal send confirmation

* MILLIX-76: redesign peer detail page (#13)

* MILLIX-76: redesign peer detail page

* balance, addresses, bug fixes, ad validation, errors, send result (#14)

* do not show node public address if node is not public
* MILLIX-78 - left nav glitch on low resolution
* MILLIX-79 - do not show node public address if node is not public
* MILLIX-78 - left nav glitch on low resolution
* MILLIX-82 - create ad amounts validation. restore validation bid_per_impressions_mlx against daily budget
* MILLIX-56 - send tx with 128+ inputs error message and hints
* MILLIX-80 - amount sorting bodyTemplateAmount
refactor datatable usages
* MILLIX-83 - make error list less aggressive
* format helper
send confirmation modal text
* modal-view.jsx - on_close
send - fix confirmation modal
* MILLIX-84 - balance-view.jsx
MILLIX-85 - address-list-view.jsx
cleanup moment.relativeTimeThreshold
format.date
* primary_address hints
* cleanup tables
* MILLIX-83 - standardize stable/pending unspent related terms
* MILLIX-83 - show transaction id in send result modal
unspent-transaction-output-view.jsx - notes

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-76 - peer detail (#15)

MILLIX-76 - peer detail

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-89 - create-ad-view.jsx sort categories by label, list-ad-view fix empty categories and types, fix create button label (#16)

* MILLIX-89 - list-ad-view fix empty categories and types, fix create button label
* MILLIX-89 - create-ad-view.jsx sort categories by label

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-84 - balance panel, update help items (#20)

MILLIX-84 - balance panel, update help items
update transaction details

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* millix 95 send empty error. improve validation (#21)

MILLIX-95 - wallet-view.jsx - handle errors. improve validation
help-icon-view.jsx remove trailing dots
validate.js helper
fix unlock-wallet-view.jsx error
fix .editorconfig max line length
Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* validate.handleAmountInputChange

* MILLIX-108 - datatable search (#23)

MILLIX-108 - datatable search
move datatable header in datatable view
MILLIX-107 - incomplete commented filter

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-109 - add key identifier to header, stats, report
fix private_key_exists variable name

* MILLIX-28 - fix unreliable sidebar node version

* datatable-view.jsx fix reload_datatable call

* wallet-view.jsx send - fix sending a few tx in a row

* MILLIX-118 - send confirmation message wrong address

* MILLIX-124 - newSession* escape url params before send (#24)

MILLIX-124 - newSession* escape url params before send
fix success condition: login consider everything but success as fail

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* Millix 128 left nav unspent note (#25)

* MILLIX-128 - left nav place stable unspent above pending. fix unspent note style
* MILLIX-128 - fix ad list note style

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-111 - transaction_send_interrupt empty message

* millix 127 design (#26)

* MILLIX-127 - redesign, remove unused vendor files

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* Issue/millix 58 (#17)

* millix-58 - reset all unspent, reset single tx, reset single unspent

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* peer-info-view.jsx fix console error

* MILLIX-110 standardize alignment of text in modals

* remove key identifier from header

* remove import of css that appeared after conflict merge

* Millix 130 (#27)

global loader
loader on logout

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* Millix 102 (#31)

MILLIX-102: settings pages

Co-authored-by: AShulpekov <ash52131@gmail.com>
Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-134: add new version badge (#37)

MILLIX-134: add new version badge

Co-authored-by: AShulpekov <ash52131@gmail.com>
Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* Millix 151 (#30)

show error modal on api request fail
refactor api calls structure

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* MILLIX-54 Adding new options to actions (#33)

* MILLIX-54 cleanup config pages, cleanup action page. add backup action panel

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* Millix 52 (#39)

MILLIX-52 - get price from fiatleak.com and show stable balance in fiat

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* SHOW_API_ERROR_IN_MODAL environment.js

* format.millix fix zero amount

* Restart the initial values of state in redux reducer when LOCK_WALLET (#32)

millix-129 data remain in ui after logout and login to a different wallet

Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>

* fiat balance
rearrange left nav items

* fix typo
fix empty config on login
update transaction_input_max_error message

* failed to fetch error message

Co-authored-by: ksenia404publishing <96577545+ksenia404publishing@users.noreply.github.com>
Co-authored-by: Alex Olkhovskii <alex.olkhovskii@gmail.com>
Co-authored-by: dkhaleev <dkhaleev@gmail.com>
Co-authored-by: antonshulpekov <98457590+antonshulpekov@users.noreply.github.com>
Co-authored-by: Matias Negri <mati_negri@hotmail.com>
Co-authored-by: AShulpekov <ash52131@gmail.com>