### PR TITLE
millix 224

### DIFF
--- a/src/css/alert.scss
+++ b/src/css/alert.scss
@@ -8,3 +8,8 @@
   }
 }
 
+.alert-warning {
+  color: $color-white;
+  border-color: rgba($color-yellow, 0.5);
+  background-color: rgba($color-yellow, 0.05);
+}

--- a/src/css/layout.scss
+++ b/src/css/layout.scss
@@ -489,7 +489,3 @@ h4, .h4, h5, .h5, h6, .h6 {
   }
 }
 
-.nft-preview-description {
-  margin-top: 1rem;
-}
-

--- a/src/css/loader.scss
+++ b/src/css/loader.scss
@@ -49,7 +49,7 @@
   z-index: 9999;
 }
 
-.loader-container .loader .circle {
+.loader .circle {
   animation: spin 1s linear infinite;
   border: 0.5rem solid $border-color;
   border-top: 0.5rem solid $color-primary;

--- a/src/css/nft.scss
+++ b/src/css/nft.scss
@@ -64,7 +64,8 @@
   min-height: 1.5rem;
 }
 
-.nft-collection-img {
+.nft-collection-img,
+.nft-preview-img {
   padding: 1rem 0 0 0;
   width: 100%;
   height: 24rem;
@@ -76,6 +77,11 @@
     align-self: flex-start;
     margin: 0 auto;
   }
+}
+
+.nft-preview-img {
+  max-height: 48rem;
+  height: auto;
 }
 
 .nft-action-section {
@@ -99,4 +105,9 @@
 
 .nftActionSummaryPopover {
   z-index: 1010;
+}
+
+.nft-preview-description {
+  margin-top: 1rem;
+  text-align: center;
 }

--- a/src/css/nft.scss
+++ b/src/css/nft.scss
@@ -80,8 +80,12 @@
 }
 
 .nft-preview-img {
-  max-height: 48rem;
   height: auto;
+  text-align: center;
+
+  img {
+    max-height: 48rem;
+  }
 }
 
 .nft-action-section {

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,8 @@ import {
     faCopy,
     faCaretDown,
     faArrowRightArrowLeft,
-    faFile
+    faFile,
+    faTriangleExclamation
 } from '@fortawesome/free-solid-svg-icons';
 import './css/bootstrap/bootstrap.scss';
 
@@ -90,7 +91,7 @@ library.add(faArrowCircleLeft, faWallet, faKey, faHome, faFingerprint,
     faPause, faQuestionCircle, faThList, faRedo, faEllipsisV,
     faChainSlash, faChainBroken,
     faRotateLeft, faCodeMerge, faCheckCircle, faReply, faEnvelope, faLink, faFire, faBomb,
-    faArrowRight, faUpload, faMinusCircle, faCopy, faCaretDown, faArrowRightArrowLeft, faFile);
+    faArrowRight, faUpload, faMinusCircle, faCopy, faCaretDown, faArrowRightArrowLeft, faFile, faTriangleExclamation);
 
 
 let apiInfo = {

--- a/src/js/api/index.js
+++ b/src/js/api/index.js
@@ -230,6 +230,14 @@ class API {
         });
     }
 
+    getTransactionWithDataReceived(transaction_id, data_type) {
+        return this.fetchApiMillix(`/yyCtgjuFu9mx0edg`, {
+            p0 : transaction_id,
+            p2: 'Adl87cz8kC190Nqc',
+            p3: data_type
+        });
+    }
+
     sendAggregationTransaction() {
         return this.fetchApiMillix(`/kC5N9Tz06b2rA4Pg`);
     }

--- a/src/js/components/nft/nft-action-summary.jsx
+++ b/src/js/components/nft/nft-action-summary.jsx
@@ -199,6 +199,14 @@ class NftActionSummaryView extends Component {
                                 </button>
                             </Col>
                         </Form.Group>
+                        <div className={'mt-3'}>
+                            <Button
+                                variant="outline-default"
+                                className={'w-100'}
+                                onClick={() => this.props.history.push('/transaction/' + this.state.nft_data.txid)}>
+                                <FontAwesomeIcon icon={'list'}/>transaction
+                            </Button>
+                        </div>
                         {owner_action_list}
                         {detail_link}
                     </div>

--- a/src/js/components/nft/nft-collection-view.jsx
+++ b/src/js/components/nft/nft-collection-view.jsx
@@ -1,17 +1,13 @@
 import React, {Component} from 'react';
 import {withRouter} from 'react-router-dom';
-import {Button, Card, Col, Form, Row} from 'react-bootstrap';
+import {Button, Card, Col, Row} from 'react-bootstrap';
 import API from '../../api';
 import {connect} from 'react-redux';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import * as format from '../../helper/format';
-import ModalView from '../utils/modal-view';
-import * as text from '../../helper/text';
 import {changeLoaderState} from '../loader';
-import Transaction from '../../common/transaction';
 import async from 'async';
 import utils from '../../helper/utils';
-import {TRANSACTION_DATA_TYPE_ASSET, TRANSACTION_DATA_TYPE_NFT, TRANSACTION_DATA_TYPE_TRANSACTION} from '../../../config';
+import {TRANSACTION_DATA_TYPE_NFT} from '../../../config';
 import HelpIconView from '../utils/help-icon-view';
 import moment from 'moment';
 import ReloadTimeTickerView from '../utils/reload-time-ticker-view';
@@ -77,11 +73,13 @@ class NftCollectionView extends Component {
                       name,
                       description
                   } = image_props;
+
+            let image = <img src={src} alt={alt}/>;
             nft_list_formatted.push(
                 <Col xs={12} md={3} className={'mt-3'} key={transaction.transaction_id}>
                     <Card className={'nft-card'}>
                         <div className={'nft-collection-img'}>
-                            <img src={src} alt={alt}/>
+                            {image}
                         </div>
                         <Card.Body>
                             <div className={'nft-name page_subtitle'}>{name}</div>

--- a/src/js/components/nft/nft-preview-view.jsx
+++ b/src/js/components/nft/nft-preview-view.jsx
@@ -224,7 +224,10 @@ class NftPreviewView extends Component {
             if (this.state.error_list.length === 0) {
                 nft_body = <>
                     {!this.isOwner() &&
-                     <div className={'alert alert-warning'}>
+                     <div className={'text-warning labeled'}>
+                         <FontAwesomeIcon
+                             icon={'triangle-exclamation'}
+                             size="1x"/>
                          there is no guarantee that this nft is currently owned by the person that sent you this preview link. the only way to safely buy an nft
                          is through an escrow service or trusted marketplace.
                      </div>

--- a/src/js/components/nft/nft-preview-view.jsx
+++ b/src/js/components/nft/nft-preview-view.jsx
@@ -18,6 +18,7 @@ import utils from '../../helper/utils';
 import {changeLoaderState} from '../loader';
 import * as validate from '../../helper/validate';
 import HelpIconView from '../utils/help-icon-view';
+import WarningList from '../utils/warning-list-view';
 
 
 class NftPreviewView extends Component {
@@ -31,9 +32,11 @@ class NftPreviewView extends Component {
             nft_sync_timestamp      : moment.now(),
             modal_show_copy_result  : false,
             error_list              : [],
+            warning_list            : [],
             transaction_history_list: [],
             dnsValidated            : false,
-            dns                     : ''
+            dns                     : '',
+            warning_message         : []
         };
 
         this.timeout_id = null;
@@ -71,35 +74,64 @@ class NftPreviewView extends Component {
             sync_request_image,
             sync_request_metadata
         ]).then((result_sync) => {
-            const result_image    = result_sync[0];
-            const result_metadata = result_sync[1];
-
-            this.setState({
-                status            : result_image.status,
-                nft_sync_timestamp: moment.now()
-            });
+            const result_image       = result_sync[0];
+            const result_metadata    = result_sync[1];
+            const nft_sync_timestamp = moment.now();
+            let status_new           = result_image.status;
 
             if (result_image.status !== 'syncing' && result_metadata.status !== 'syncing') {
                 clearTimeout(this.timeout_id);
-                API.listTransactionWithDataReceived(this.state.parameter_list.address_key_identifier_to, TRANSACTION_DATA_TYPE_NFT)
-                   .then(transaction_list => {
-                       const transaction = transaction_list.filter((entry) => entry.transaction_id === this.state.parameter_list.transaction_id)[0];
 
+                API.getTransactionWithDataReceived(this.state.parameter_list.transaction_id, TRANSACTION_DATA_TYPE_NFT)
+                   .then(transaction => {
+                       let warning_list = [];
+                       let error_list   = [];
                        if (!transaction) {
+                           error_list.push({
+                               message: 'nft not found'
+                           });
+                       }
+                       else if (transaction.is_double_spend !== 0) {
+                           error_list.push({
+                               message: 'the nft you are viewing has been sent to more than one recipient, or was minted using invalid funds, and only one version is considered valid. the version of the nft that you are viewing is considered to be an invalid copy of the nft.'
+                           });
+                       }
+                       else if (transaction.is_spent !== 0) {
+                           error_list.push({
+                               message: 'the ownership and validity of nfts can change at any time, reload the page to see the most current state of this nft.'
+                           });
+                       }
+                       else if (transaction.is_stable !== 1) {
+                           status_new = 'syncing';
+                           warning_list.push({
+                               message: 'your browser has not validated this nft transaction yet. continue to reload the page to see the current state of this nft transaction.'
+                           });
+                       }
+
+                       if (error_list.length > 0) {
                            this.setState({
-                               error_list: [
-                                   {
-                                       message: 'nft not found'
-                                   }
-                               ]
+                               nft_sync_timestamp: nft_sync_timestamp,
+                               error_list        : error_list,
+                               warning_list      : warning_list,
+                               status            : status_new
                            });
                        }
                        else {
                            transaction.file_key = this.state.parameter_list.key;
+
                            utils.getImageFromApi(transaction)
                                 .then(image_data => {
+                                    if (!this.isOwner()) {
+                                        warning_list.push({
+                                            message: 'there is no guarantee that this nft is currently owned by the person that sent you this preview link. the only way to safely buy an nft is through an escrow service or trusted marketplace.'
+                                        });
+                                    }
+
                                     this.setState({
-                                        image_data
+                                        nft_sync_timestamp: nft_sync_timestamp,
+                                        image_data,
+                                        status            : status_new,
+                                        warning_list      : warning_list
                                     });
 
                                     if (image_data.dns) {
@@ -114,6 +146,10 @@ class NftPreviewView extends Component {
                    });
             }
             else {
+                this.setState({
+                    nft_sync_timestamp: nft_sync_timestamp,
+                    status            : 'syncing'
+                });
                 setTimeout(() => this.setNftData(), 10000);
             }
         }).catch(_ => {
@@ -219,19 +255,11 @@ class NftPreviewView extends Component {
             }
         }
 
+        let load_control;
         let nft_body;
         if (this.state.status !== 'syncing') {
             if (this.state.error_list.length === 0) {
                 nft_body = <>
-                    {!this.isOwner() &&
-                     <div className={'text-warning labeled'}>
-                         <FontAwesomeIcon
-                             icon={'triangle-exclamation'}
-                             size="1x"/>
-                         there is no guarantee that this nft is currently owned by the person that sent you this preview link. the only way to safely buy an nft
-                         is through an escrow service or trusted marketplace.
-                     </div>
-                    }
                     <div className={'nft-preview-img'}>
                         <a href={this.state.image_data.src} target={'_blank'} className={'mx-auto d-flex'}>
                             <img src={this.state.image_data.src} alt={this.state.image_data.name}/>
@@ -275,8 +303,9 @@ class NftPreviewView extends Component {
                 </>;
             }
         }
-        else {
-            nft_body = <Row className={'align-items-center'}>
+
+        if (this.state.status !== 'synced') {
+            load_control = <Row className={'align-items-center mb-3'}>
                 <Col md={5}>
                     <Button variant="outline-primary"
                             size={'sm'}
@@ -309,8 +338,9 @@ class NftPreviewView extends Component {
                 </div>
             </div>
             <div className={'panel-body'}>
-                <ErrorList
-                    error_list={this.state.error_list}/>
+                {load_control}
+                <ErrorList error_list={this.state.error_list} class_name={'mb-0'}/>
+                <WarningList warning_list={this.state.warning_list} class_name={'mb-0'}/>
                 {nft_body}
             </div>
 

--- a/src/js/components/nft/nft-preview-view.jsx
+++ b/src/js/components/nft/nft-preview-view.jsx
@@ -177,7 +177,7 @@ class NftPreviewView extends Component {
                          is through an escrow service or trusted marketplace.
                      </div>
                     }
-                    <div className={'nft-collection-img'}>
+                    <div className={'nft-preview-img'}>
                         <a href={this.state.image_data.src} target={'_blank'} className={'mx-auto d-flex'}>
                             <img src={this.state.image_data.src} alt={this.state.image_data.name}/>
                         </a>

--- a/src/js/components/utils/error-list-view.jsx
+++ b/src/js/components/utils/error-list-view.jsx
@@ -16,7 +16,7 @@ const ErrorList = (props) => {
 
     if (Object.keys(error_list).length > 0) {
         return (
-            <div className="alert alert-danger" role="alert">
+            <div className={'alert alert-danger ' + props.class_name} role="alert">
                 <ul>
                     {error_list.map((error, idx) =>
                         <li key={'message_' + idx}>

--- a/src/js/components/utils/file-upload.jsx
+++ b/src/js/components/utils/file-upload.jsx
@@ -37,11 +37,8 @@ class FileUpload extends Component {
         });
     }
 
-    onFileInputClick() {
-        this.clearFileInput();
-    }
-
     clearFileInput() {
+        this.input_file_ref.value = null;
         this.setState({
             image_data: null
         });
@@ -93,7 +90,6 @@ class FileUpload extends Component {
                         ref={input => this.input_file_ref = input}
                         name={'file_upload'}
                         onChange={event => this.handleFileChange(event)}
-                        onClick={() => this.onFileInputClick()}
                         accept={this.props.accept}
                     />
                 </div>

--- a/src/js/components/utils/warning-list-view.jsx
+++ b/src/js/components/utils/warning-list-view.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const WarningList = (props) => {
+    let warning_list = props.warning_list;
+
+    if (warning_list.length > 0 && typeof (warning_list[0]) === 'string') {
+        let result_warning = [];
+        warning_list.map(item => {
+            result_warning.push({
+                message: item
+            });
+        });
+
+        warning_list = result_warning;
+    }
+
+    if (Object.keys(warning_list).length > 0) {
+        return (
+            <div className={'alert alert-warning ' + props.class_name} role="alert">
+                <ul>
+                    {warning_list.map((warning, idx) =>
+                        <li key={'message_' + idx}>
+                            {warning.message}
+                        </li>
+                    )}
+                </ul>
+            </div>
+        );
+    }
+
+    return '';
+};
+
+export default WarningList;

--- a/src/js/helper/utils.js
+++ b/src/js/helper/utils.js
@@ -78,7 +78,8 @@ function nftImageData(transaction) {
         name                       : file_data_tangled_nft_meta?.name,
         description                : file_data_tangled_nft_meta?.description,
         attribute_type_id          : attribute.attribute_type_id,
-        file_key                   : file_key
+        file_key                   : file_key,
+        dns                        : attribute.value.dns
     };
 }
 
@@ -88,7 +89,7 @@ function getNftViewLink(nft_data, absolute = false) {
         origin = window.location.origin;
         try {
             let environment = require('../../environment');
-            environment       = environment.default;
+            environment     = environment.default;
             if (environment.NFT_VIEW_LINK_ORIGIN) {
                 origin = environment.NFT_VIEW_LINK_ORIGIN;
             }
@@ -100,8 +101,7 @@ function getNftViewLink(nft_data, absolute = false) {
     return `${origin}/nft-preview/?p0=${nft_data.transaction.transaction_id}&p1=${nft_data.transaction.address_key_identifier_to}&p2=${nft_data.file_key}&p3=${nft_data.hash}&p4=${nft_data.metadata_hash}`;
 }
 
-function is_main_network_address(address_key_identifier)
-{
+function is_main_network_address(address_key_identifier) {
     return address_key_identifier.startsWith('1');
 }
 


### PR DESCRIPTION
- if you remove image from the form and try to upload it again, it is not added
- preview seems to be too small
- text align center name and description on preview
- after nft burned and you open a link you see "nft not found" error. price consider it as inaccurate message. replace with "The nft you are viewing has been transferred from the previous transaction to a new transaction.  This may indicate that the nft is no longer owned by the wallet that provided you this preview link or has been burned."
- there is no link to transaction on nft preview
- if transaction doesn't have is_stable 1 it means it can still be a double spend and node didn't validate it. keep checking and show a warning to a user?
- if you click the image it opens in a new tab, the tab label tangled favicon doesn't look sharp
- show verified sender at the preview page